### PR TITLE
DCE-41: Principle Variation Table

### DIFF
--- a/src/engine/game.rs
+++ b/src/engine/game.rs
@@ -1,6 +1,7 @@
 use crate::engine::shared::structures::castling_struct::CastlingRights;
 use crate::engine::shared::structures::square::*;
 use super::move_generation::fen::FenTrait;
+use super::search::transposition_table::PvTable;
 use super::shared::helper_func::bitboard::*;
 use super::shared::helper_func::const_utility::*;
 use super::shared::structures::color::*;
@@ -19,6 +20,8 @@ pub struct Game {
     pub pos_key: u64,
 
     pub moves: Vec<InternalMove>,
+
+    pub pv: PvTable,
 }
 
 impl Game {
@@ -39,6 +42,7 @@ impl Game {
             pos_key: 0,
 
             moves: Vec::with_capacity(1024),
+            pv: PvTable::init(),
         }
     }
 
@@ -52,6 +56,7 @@ impl Game {
         self.half_move = 0;
         self.full_move = 1;
         self.moves = Vec::with_capacity(1024);
+        self.pv = PvTable::init();
     }
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod attacks;
 pub mod game;
 pub mod move_generation;
+pub mod search;
 pub mod shared;

--- a/src/engine/move_generation/mod.rs
+++ b/src/engine/move_generation/mod.rs
@@ -1,4 +1,5 @@
 pub mod fen;
+
 pub mod make_move;
 pub mod mv_gen;
 pub mod perft;

--- a/src/engine/search/mod.rs
+++ b/src/engine/search/mod.rs
@@ -1,0 +1,1 @@
+pub mod transposition_table;

--- a/src/engine/search/transposition_table.rs
+++ b/src/engine/search/transposition_table.rs
@@ -1,0 +1,98 @@
+use crate::engine::{
+    game::Game,
+    move_generation::{
+        make_move::{GameMoveTrait},
+        mv_gen::gen_moves,
+    },
+    shared::structures::internal_move::InternalMove,
+};
+
+const MAX_TT_ENTRIES: usize = 5000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PvEntry {
+    pos_key: u64,
+    mv: InternalMove,
+}
+
+impl PvEntry {
+    fn init(pos_key: u64, mv: InternalMove) -> Self {
+        Self { pos_key, mv }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PvTable {
+    pub table: [Option<PvEntry>; MAX_TT_ENTRIES],
+}
+
+impl PvTable {
+    pub fn init() -> Self {
+        Self { table: [None; MAX_TT_ENTRIES] }
+    }
+
+    fn idx(pos_key: u64) -> usize {
+        return (pos_key % MAX_TT_ENTRIES as u64) as usize;
+    }
+
+    pub fn set(&mut self, pos_key: u64, mv: InternalMove) {
+        self.table[Self::idx(pos_key)] = Some(PvEntry::init(pos_key, mv));
+    }
+
+    pub fn get(&self, pos_key: u64) -> Option<InternalMove> {
+        let idx = Self::idx(pos_key);
+        if let Some(entry) = self.table[idx] {
+            if entry.pos_key == pos_key {
+                return Some(entry.mv);
+            }
+        }
+        return None;
+    }
+
+    pub fn get_line(&mut self, game: &mut Game, pos_key: u64) -> usize {
+        let mut mv = Self::get(&self, pos_key);
+        let mut idx: usize = 0;
+        let count: usize;
+
+        while let Some(int_mv) = mv {
+            if idx >= 64 {
+                break;
+            }
+
+            if move_exists(game, &int_mv) {
+                game.make_move(&int_mv);
+                self.table[idx] = Some(PvEntry::init(pos_key, int_mv));
+                idx += 1;
+            } else {
+                break;
+            }
+
+            mv = Self::get(&self, int_mv.position_key);
+        }
+
+        count = idx;
+
+        while idx > 0 {
+            game.undo_move();
+            idx -= 1;
+        }
+
+        count
+    }
+
+    pub fn clear(&mut self) {
+        self.table.fill(None);
+    }
+}
+
+pub fn move_exists(game: &mut Game, internal_mv: &InternalMove) -> bool {
+    let mut move_list: Vec<InternalMove> = gen_moves(game.color, game);
+
+    for mv in &mut move_list {
+        if *mv != *internal_mv && game.make_move(mv) {
+            game.undo_move();
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub mod engine {
         pub mod mv_gen;
         pub mod perft;
     }
+    pub mod search {
+        pub mod transposition_table;
+    }
     pub mod shared {
         pub mod helper_func {
             pub mod bit_pos_utility;


### PR DESCRIPTION
# Jira Ticket: DCE-41
## Summary (Provide a summary of the changes.)
- Created Principle Variation Table
-

## Checklist
- [x] All Tests are Correct.
- [x] Merged with the master branch.

## Additional Notes (Any additional context, screenshots, or relevant information.)
- If I need to get the value of the array in MB: println!("The useful size of `v` is {} in Bytes  and {} in MB", size_of_val(&game.pv.table), size_of_val(&game.pv.table) / 1000000);
- https://users.rust-lang.org/t/storage-of-structs-in-memory/69916
- Also, it should be noted that every boolean and u8 take the same place in memory (1 Byte) where only the right bit is applied for the boolean (Very Important).
- I also learned about "usize", it is stored on my machine as a u64 (8 Bytes) which adds a lot of unnecessary memory for the information that I need (In the future I should rewrite the Internal Move to not use usize but u8 for the most parts).
- Also cargo bitflags package should be checked if it adds some overhead to the memory of Internal Move. (Maybe remove it).
- Now we are at 5000 elements before overloading, make it 150000 (increase 30 times).
