### PR TITLE
DCE-52: Update Internal Move

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ name = "chess-engine"
 path = "src/main.rs"
 
 [[bench]]
-name = "library_benchmark"
+# name = "library_benchmark"
 strip = false
 debug = true
-# name = "my_benchmark"
-# harness = false
+name = "my_benchmark"
+harness = false
 
 [profile.dev]
 opt-level = 1

--- a/src/engine/attacks/pawn.rs
+++ b/src/engine/attacks/pawn.rs
@@ -22,7 +22,7 @@ pub fn get_pawn_mv(color: Color, sq: usize, own: u64, enemy: u64) -> u64 {
 }
 
 #[inline(always)]
-pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<usize>) -> u64 {
+pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<u8>) -> u64 {
     let attacks = PAWN_ATTACK_LOOKUP[color.idx()][sq] & !own;
     match ep {
         Some(ep) => attacks & (enemy | get_pawn_ep(color, ep)),
@@ -31,8 +31,8 @@ pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<us
 }
 
 #[inline(always)]
-pub fn get_pawn_ep(color: Color, ep: usize) -> u64 {
-    let rank_ep = get_bit_rank(ep);
+pub fn get_pawn_ep(color: Color, ep: u8) -> u64 {
+    let rank_ep = get_bit_rank(ep as usize);
     if (rank_ep == Rank::Six && color.is_white()) || (rank_ep == Rank::Three && color.is_black()) {
         1 << ep
     } else {

--- a/src/engine/fen/fen.rs
+++ b/src/engine/fen/fen.rs
@@ -67,7 +67,7 @@ impl FenTrait for Game {
         self.ep = match square {
             "-" => None,
             s => match position_to_bit(s) {
-                Ok(bit) => Some(bit.get_lsb()),
+                Ok(bit) => Some(bit.get_lsb() as u8),
                 Err(e) => panic!("Unknown En Passant Position: {}", e),
             },
         }
@@ -138,7 +138,7 @@ mod tests {
         let game = Game::read_fen(FEN_PAWNS_BLACK);
         assert_eq!(game.color, BLACK);
         assert_eq!(game.castling, CastlingRights::ALL);
-        assert_eq!(game.ep, Some(SqPos::E3 as usize));
+        assert_eq!(game.ep, Some(SqPos::E3 as u8));
         assert_eq!(game.half_move, 0);
         assert_eq!(game.full_move, 1);
 

--- a/src/engine/game.rs
+++ b/src/engine/game.rs
@@ -3,7 +3,7 @@ use super::search::transposition_table::TTTable;
 use super::shared::helper_func::bitboard::*;
 use super::shared::helper_func::const_utility::*;
 use super::shared::structures::color::*;
-use super::shared::structures::internal_move::InternalMove;
+use super::shared::structures::internal_move::Position;
 use crate::engine::shared::structures::castling_struct::CastlingRights;
 use crate::engine::shared::structures::square::*;
 
@@ -20,11 +20,11 @@ pub struct Game {
     pub full_move: usize,
     pub pos_key: u64,
 
-    pub moves: Vec<InternalMove>,
+    pub moves: Vec<Position>,
 
     pub tt: TTTable,
     pub s_history: [[u64; 64]; 14], // FIXME: Rename This and check for better takes implementation because it takes a lot of memory
-    pub s_killers: [[u64; 2]; 2048], // FIXME: Rename This and check for better takes implementation because it takes a lot of memory
+    pub s_killers: [[u64; 2]; 64], // FIXME: Rename This and check for better takes implementation because it takes a lot of memory
     pub ply: usize,
 }
 
@@ -48,7 +48,7 @@ impl Game {
             moves: Vec::with_capacity(1024),
             tt: TTTable::init(),
             s_history: [[0u64; 64]; 14],
-            s_killers: [[0u64; 2]; 2048],
+            s_killers: [[0u64; 2]; 64],
             ply: 0,
         }
     }

--- a/src/engine/move_generation/make_move.rs
+++ b/src/engine/move_generation/make_move.rs
@@ -11,7 +11,7 @@ use core::panic;
 use super::mv_gen::sq_attack;
 
 pub trait GameMoveTrait {
-    fn make_move(&mut self, mv: &InternalMove) -> bool;
+    fn make_move(&mut self, mv: &Position) -> bool;
     fn undo_move(&mut self);
     fn generate_pos_key(&mut self);
     fn add_piece(&mut self, sq: usize, piece: Piece);

--- a/src/engine/move_generation/mv_gen.rs
+++ b/src/engine/move_generation/mv_gen.rs
@@ -40,6 +40,8 @@ pub fn gen_moves(color: Color, game: &Game) -> (PositionIrr, Vec<PositionRev>) {
         }
     }
 
+    add_castling_moves(&(KING + color), game, &mut positions_rev);
+
     (position_irr, positions_rev)
 }
 
@@ -111,10 +113,6 @@ fn get_positions_rev(
             new_positions.push(new_move)
         }
     }
-
-    if piece.is_king() {
-        add_castling_moves(piece, from_sq as u8, game, new_positions);
-    }
 }
 
 pub fn is_repetition(game: &Game) -> bool {
@@ -142,23 +140,47 @@ pub fn move_exists(game: &mut Game, rev: &PositionRev) -> bool {
 }
 
 #[inline(always)]
-pub fn add_castling_moves(piece: &Piece, from: u8, game: &Game, positions: &mut Vec<PositionRev>) {
+pub fn add_castling_moves(piece: &Piece, game: &Game, positions: &mut Vec<PositionRev>) {
     let (own, enemy) = get_occupancy(piece, game);
     match piece.color() {
         WHITE => {
             if game.castling.valid(CastlingRights::WKINGSIDE, game, own, enemy) {
-                positions.push(PositionRev::init(from, G1 as u8, *piece, None, Flag::KingCastle));
+                positions.push(PositionRev::init(
+                    E1 as u8,
+                    G1 as u8,
+                    *piece,
+                    None,
+                    Flag::KingCastle,
+                ));
             }
             if game.castling.valid(CastlingRights::WQUEENSIDE, game, own, enemy) {
-                positions.push(PositionRev::init(from, C1 as u8, *piece, None, Flag::QueenCastle));
+                positions.push(PositionRev::init(
+                    E1 as u8,
+                    C1 as u8,
+                    *piece,
+                    None,
+                    Flag::QueenCastle,
+                ));
             }
         }
         BLACK => {
             if game.castling.valid(CastlingRights::BKINGSIDE, game, own, enemy) {
-                positions.push(PositionRev::init(from, G8 as u8, *piece, None, Flag::KingCastle));
+                positions.push(PositionRev::init(
+                    E8 as u8,
+                    G8 as u8,
+                    *piece,
+                    None,
+                    Flag::KingCastle,
+                ));
             }
             if game.castling.valid(CastlingRights::BQUEENSIDE, game, own, enemy) {
-                positions.push(PositionRev::init(from, C8 as u8, *piece, None, Flag::QueenCastle));
+                positions.push(PositionRev::init(
+                    E8 as u8,
+                    C8 as u8,
+                    *piece,
+                    None,
+                    Flag::QueenCastle,
+                ));
             }
         }
         _ => panic!("Invalid Castling"),

--- a/src/engine/move_generation/mv_gen.rs
+++ b/src/engine/move_generation/mv_gen.rs
@@ -13,13 +13,22 @@ use crate::engine::shared::structures::color::*;
 use crate::engine::shared::structures::internal_move::*;
 use crate::engine::shared::structures::piece::*;
 use crate::engine::shared::structures::square::SqPos::*;
-use crate::engine::shared::structures::square::*;
 
 use super::make_move::GameMoveTrait;
 
 #[inline(always)]
-pub fn gen_moves(color: Color, game: &Game) -> Vec<InternalMove> {
-    let mut positions: Vec<InternalMove> = Vec::with_capacity(256);
+pub fn gen_moves(color: Color, game: &Game) -> (PositionIrr, Vec<PositionRev>) {
+    let position_irr = PositionIrr {
+        key: game.key,
+        color: game.color,
+        ep: game.ep,
+        castle: game.castling,
+        half_move: game.half_move,
+        full_move: game.full_move,
+        score: 0,
+    };
+
+    let mut positions_rev: Vec<PositionRev> = Vec::with_capacity(256);
     let (own_occ, enemy_occ) = get_occupancy(&color, game);
 
     for piece in &PIECES {
@@ -27,11 +36,11 @@ pub fn gen_moves(color: Color, game: &Game) -> Vec<InternalMove> {
         while bb != 0 {
             let pos = bb.pop_lsb();
             let moves = get_all_moves(piece + color, pos, game, own_occ, enemy_occ);
-            get_internal_moves(moves, &(piece + color), pos, game, &mut positions);
+            get_positions_rev(moves, &(piece + color), pos, game, &mut positions_rev);
         }
     }
 
-    positions
+    (position_irr, positions_rev)
 }
 
 #[inline(always)]
@@ -75,29 +84,26 @@ pub fn sq_attack(game: &Game, sq: usize, color: Color) -> u64 {
 }
 
 #[inline(always)]
-fn get_internal_moves(
+fn get_positions_rev(
     mut attacks: u64,
     piece: &Piece,
-    pos: usize,
+    from_sq: usize,
     game: &Game,
-    new_positions: &mut Vec<InternalMove>,
+    new_positions: &mut Vec<PositionRev>,
 ) {
     while attacks != 0 {
-        let p_move = attacks.pop_lsb();
-        let mut new_move = InternalMove {
-            position_key: game.pos_key,
-            active_color: game.color,
-            from: pos,
-            to: p_move,
+        let to_sq = attacks.pop_lsb();
+        let mut new_move = PositionRev {
+            from: from_sq as u8,
+            to: to_sq as u8,
             piece: *piece,
-            ep: game.ep,
-            castle: game.castling,
-            half_move: game.half_move,
-            flag: match game.squares[p_move] {
-                Square::Empty => Flag::Quiet,
-                Square::Occupied(piece) => Flag::Capture(piece),
+            capture: game.squares[to_sq],
+            flag: match game.squares[to_sq] {
+                None => Flag::Quiet,
+                Some(piece) => Flag::Capture(piece),
             },
         };
+
         if new_move.piece.is_pawn() {
             add_ep_move(&mut new_move, game);
             add_promotion_move(&new_move, game, new_positions);
@@ -107,13 +113,13 @@ fn get_internal_moves(
     }
 
     if piece.is_king() {
-        add_castling_moves(piece, pos, game, new_positions);
+        add_castling_moves(piece, from_sq as u8, game, new_positions);
     }
 }
 
 pub fn is_repetition(game: &Game) -> bool {
-    for i in (game.moves.len() - game.half_move)..game.moves.len() {
-        if game.moves[i].position_key == game.pos_key {
+    for i in (game.pos_irr.len() - game.half_move as usize)..game.pos_irr.len() {
+        if game.pos_irr[i].key == game.key {
             return true;
         }
     }
@@ -121,12 +127,12 @@ pub fn is_repetition(game: &Game) -> bool {
     false
 }
 
-pub fn move_exists(game: &mut Game, internal_mv: &InternalMove) -> bool {
-    let mut move_list: Vec<InternalMove> = gen_moves(game.color, game);
+pub fn move_exists(game: &mut Game, rev: &PositionRev) -> bool {
+    let (irr, mut pos_rev) = gen_moves(game.color, game);
 
-    for mv in &mut move_list {
-        if mv == internal_mv {
-            if game.make_move(mv) {
+    for temp_rev in &mut pos_rev {
+        if rev == temp_rev {
+            if game.make_move(rev, &irr) {
                 game.undo_move();
                 return true;
             }
@@ -135,70 +141,51 @@ pub fn move_exists(game: &mut Game, internal_mv: &InternalMove) -> bool {
     false
 }
 
-#[rustfmt::skip]
 #[inline(always)]
-pub fn add_castling_moves(piece: &Piece, pos: usize, game: &Game, positions: &mut Vec<InternalMove>) {
-    
-    let mv = InternalMove {
-            position_key: 0, 
-            active_color: game.color,
-            from: pos,
-            to: 0,
-            piece: *piece,
-            ep: game.ep,
-            castle: game.castling,
-            half_move: game.half_move,
-            flag: Flag::Quiet,
-        };
-
+pub fn add_castling_moves(piece: &Piece, from: u8, game: &Game, positions: &mut Vec<PositionRev>) {
     let (own, enemy) = get_occupancy(piece, game);
-    match mv.active_color {
+    match piece.color() {
         WHITE => {
             if game.castling.valid(CastlingRights::WKINGSIDE, game, own, enemy) {
-               positions.push(InternalMove { to: SqPos::G1.idx(), flag: Flag::KingSideCastle(H1 as usize, F1 as usize), ..mv });
+                positions.push(PositionRev::init(from, G1 as u8, *piece, None, Flag::KingCastle));
             }
             if game.castling.valid(CastlingRights::WQUEENSIDE, game, own, enemy) {
-               positions.push(InternalMove { to: SqPos::C1.idx(), flag: Flag::QueenSideCastle(A1 as usize, D1 as usize), ..mv });
+                positions.push(PositionRev::init(from, C1 as u8, *piece, None, Flag::QueenCastle));
             }
         }
-         BLACK => {
+        BLACK => {
             if game.castling.valid(CastlingRights::BKINGSIDE, game, own, enemy) {
-               positions.push(InternalMove { to: SqPos::G8.idx(), flag: Flag::KingSideCastle(H8 as usize, F8 as usize), ..mv });
+                positions.push(PositionRev::init(from, G8 as u8, *piece, None, Flag::KingCastle));
             }
             if game.castling.valid(CastlingRights::BQUEENSIDE, game, own, enemy) {
-               positions.push(InternalMove { to: SqPos::C8.idx(), flag: Flag::QueenSideCastle(A8 as usize, D8 as usize), ..mv });
+                positions.push(PositionRev::init(from, C8 as u8, *piece, None, Flag::QueenCastle));
             }
         }
-        _ => panic!("Invalid Castling")
+        _ => panic!("Invalid Castling"),
     }
-
 }
 
 #[inline(always)]
-pub fn add_ep_move(mv: &mut InternalMove, game: &Game) {
+pub fn add_ep_move(mv: &mut PositionRev, game: &Game) {
     if Some(mv.to) == game.ep {
-        let sq = mv.to + 16 * mv.active_color.idx() - 8;
-        mv.flag = Flag::EP(sq, PAWN + BLACK - mv.active_color);
+        mv.flag = Flag::EP;
     }
 }
 
 #[inline(always)]
-pub fn add_promotion_move(mv: &InternalMove, _game: &Game, positions: &mut Vec<InternalMove>) {
-    if (mv.active_color.is_white() && get_bit_rank(mv.to) == Rank::Eight)
-        || (mv.active_color.is_black() && get_bit_rank(mv.to) == Rank::One)
+pub fn add_promotion_move(mv: &PositionRev, game: &Game, positions_rev: &mut Vec<PositionRev>) {
+    if (mv.piece.is_white() && get_bit_rank(mv.to as usize) == Rank::Eight)
+        || (mv.piece.is_black() && get_bit_rank(mv.to as usize) == Rank::One)
     {
         let color = mv.piece.color();
-        let cap_piece: Option<Piece> = match mv.flag {
-            Flag::Capture(piece) => Some(piece),
-            _ => None,
-        };
+        let cap_piece: Option<Piece> = game.squares[mv.to as usize];
 
-        positions.push(InternalMove { flag: Flag::Promotion(QUEEN + color, cap_piece), ..*mv });
-        positions.push(InternalMove { flag: Flag::Promotion(ROOK + color, cap_piece), ..*mv });
-        positions.push(InternalMove { flag: Flag::Promotion(BISHOP + color, cap_piece), ..*mv });
-        positions.push(InternalMove { flag: Flag::Promotion(KNIGHT + color, cap_piece), ..*mv });
+        positions_rev.push(PositionRev { flag: Flag::Promotion(QUEEN + color, cap_piece), ..*mv });
+        positions_rev.push(PositionRev { flag: Flag::Promotion(ROOK + color, cap_piece), ..*mv });
+        positions_rev.push(PositionRev { flag: Flag::Promotion(BISHOP + color, cap_piece), ..*mv });
+        positions_rev.push(PositionRev { flag: Flag::Promotion(KNIGHT + color, cap_piece), ..*mv });
     } else {
-        positions.push(*mv);
+        positions_rev.push(*mv);
     }
 }
 
@@ -226,8 +213,8 @@ mod tests {
         let (own_occ, enemy_occ) = get_occupancy(&piece, &game);
         let all_pieces = extract_all_bits(game.bitboard[piece.idx()]);
         let piece = match game.squares[all_pieces[idx]] {
-            Square::Empty => panic!("The Piece Must exist"),
-            Square::Occupied(piece) => piece,
+            None => panic!("The Piece Must exist"),
+            Some(piece) => piece,
         };
         return extract_all_bits(get_all_moves(piece, all_pieces[idx], &game, own_occ, enemy_occ));
 
@@ -240,26 +227,26 @@ mod tests {
     #[test]
     fn test_white_pawns_mv_gen() {
         let game = Game::read_fen(&FEN_PAWNS_WHITE);
-        let moves = gen_moves(WHITE, &game);
-        assert_eq!(42, moves.len());
-        print_move_list(&moves);
+        let (_, positions) = gen_moves(WHITE, &game);
+        assert_eq!(42, positions.len());
+        print_move_list(&positions);
     }
 
     #[test]
     fn test_mv_gen() {
         let game = Game::read_fen(&FEN_CASTLE_TWO);
-        let moves = gen_moves(WHITE, &game);
+        let (_, positions) = gen_moves(WHITE, &game);
         print_chess(&game);
-        print_move_list(&moves);
-        assert_eq!(48, moves.len());
+        print_move_list(&positions);
+        assert_eq!(48, positions.len());
     }
 
     #[test]
     fn test_white_black_mv_gen() {
         let game = Game::read_fen(&FEN_PAWNS_BLACK);
-        let moves = gen_moves(BLACK, &game);
-        assert_eq!(42, moves.len());
-        print_move_list(&moves);
+        let (_, positions) = gen_moves(BLACK, &game);
+        assert_eq!(42, positions.len());
+        print_move_list(&positions);
     }
 
     #[test]

--- a/src/engine/move_generation/perft.rs
+++ b/src/engine/move_generation/perft.rs
@@ -92,19 +92,19 @@ pub fn perft(depth: usize, game: &mut Game, stats: &mut Stats) -> u64 {
         return 1;
     }
 
-    let mut move_list: Vec<InternalMove> = gen_moves(game.color, game);
-    for mv in &mut move_list {
-        if !game.make_move(mv) {
+    let (irr, mut pos_rev) = gen_moves(game.color, game);
+    for rev in &mut pos_rev {
+        if !game.make_move(rev, &irr) {
             continue;
         }
 
         if depth == 1 {
-            match mv.flag {
+            match rev.flag {
                 Flag::Quiet => stats.add_node(),
                 Flag::Capture(_) => stats.add_capture(),
-                Flag::EP(_, _) => stats.add_ep(),
+                Flag::EP => stats.add_ep(),
                 Flag::Promotion(_, _) => stats.add_promotion(),
-                Flag::KingSideCastle(_, _) | Flag::QueenSideCastle(_, _) => stats.add_castle(),
+                Flag::KingCastle | Flag::QueenCastle => stats.add_castle(),
             }
         }
 

--- a/src/engine/search/transposition_table.rs
+++ b/src/engine/search/transposition_table.rs
@@ -1,26 +1,26 @@
 use crate::engine::{
     game::Game,
     move_generation::{make_move::GameMoveTrait, mv_gen::move_exists},
-    shared::structures::internal_move::InternalMove,
+    shared::structures::internal_move::{PositionIrr, PositionRev},
 };
 
-const MAX_TT_ENTRIES: usize = 5000;
+const MAX_TT_ENTRIES: usize = 40000;
 
-// #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-// pub struct TTEntry {
-//     pub pos_key: u64,
-//     pub mv: InternalMove,
-// }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TTEntry {
+    pub key: u64,
+    pub rev: PositionRev,
+}
 
-// impl TTEntry {
-//     fn init(pos_key: u64, mv: InternalMove) -> Self {
-//         Self { pos_key, mv }
-//     }
-// }
+impl TTEntry {
+    fn init(key: u64, rev: PositionRev) -> Self {
+        Self { key, rev }
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TTTable {
-    pub table: [Option<InternalMove>; MAX_TT_ENTRIES],
+    pub table: [Option<TTEntry>; MAX_TT_ENTRIES],
 }
 
 impl TTTable {
@@ -28,19 +28,19 @@ impl TTTable {
         Self { table: [None; MAX_TT_ENTRIES] }
     }
 
-    pub fn idx(pos_key: u64) -> usize {
-        return (pos_key % MAX_TT_ENTRIES as u64) as usize;
+    pub fn idx(key: u64) -> usize {
+        return (key % MAX_TT_ENTRIES as u64) as usize;
     }
 
-    pub fn set(&mut self, pos_key: u64, mv: InternalMove) {
-        self.table[Self::idx(pos_key)] = Some(mv);
+    pub fn set(&mut self, key: u64, rev: PositionRev) {
+        self.table[Self::idx(key)] = Some(TTEntry::init(key, rev));
     }
 
-    pub fn get(&self, pos_key: u64) -> Option<InternalMove> {
-        let idx = Self::idx(pos_key);
-        if let Some(mv) = self.table[idx] {
-            if mv.position_key == pos_key {
-                return Some(mv);
+    pub fn get(&self, key: u64) -> Option<TTEntry> {
+        let idx = Self::idx(key);
+        if let Some(entry) = self.table[idx] {
+            if entry.key == key {
+                return Some(entry);
             }
         }
         return None;
@@ -51,25 +51,27 @@ impl TTTable {
     }
 }
 
-pub fn get_line(game: &mut Game, pos_key: u64) -> Vec<InternalMove> {
-    let mut line: Vec<InternalMove> = Vec::with_capacity(64); // TODO: Max Depth Add as a constant
+pub fn get_line(game: &mut Game, pos_key: u64) -> Vec<PositionRev> {
+    let mut line: Vec<PositionRev> = Vec::with_capacity(64); // TODO: Max Depth Add as a constant
     let mut optional_mv = TTTable::get(&game.tt, pos_key);
     let mut idx = 0;
+    let mut irr: PositionIrr;
 
     while let Some(mv) = &optional_mv {
         if line.len() >= 64 {
             break;
         }
 
-        line.push(*mv);
+        line.push(mv.rev);
 
-        if move_exists(game, mv) {
+        if move_exists(game, &mv.rev) {
             idx += 1;
-            game.make_move(mv);
+            irr = PositionIrr::init_with_game(game);
+            game.make_move(&mv.rev, &irr);
         } else {
             break;
         }
-        optional_mv = TTTable::get(&game.tt, game.pos_key);
+        optional_mv = TTTable::get(&game.tt, game.key);
     }
 
     for _ in 0..idx {

--- a/src/engine/shared/helper_func/play_chess_utility.rs
+++ b/src/engine/shared/helper_func/play_chess_utility.rs
@@ -16,10 +16,12 @@ use crate::engine::shared::helper_func::print_utility::move_notation;
 use crate::engine::shared::helper_func::print_utility::print_chess;
 use crate::engine::shared::helper_func::print_utility::print_move_list;
 use crate::engine::shared::structures::internal_move::Flag;
-use crate::engine::shared::structures::internal_move::InternalMove;
+use crate::engine::shared::structures::internal_move::PositionRev;
+use crate::engine::shared::structures::piece::PieceTrait;
 
 pub fn play_chess(game: &mut Game, info: &mut SearchInfo) {
-    let mut move_list: Vec<InternalMove>;
+    // let mut move_list: Vec<InternalMove>;
+    let mut move_list: Vec<PositionRev>;
     gen_moves(game.color, game);
 
     loop {
@@ -83,11 +85,11 @@ pub fn play_chess(game: &mut Game, info: &mut SearchInfo) {
             str => {
                 move_list = gen_moves(game.color, game);
                 for mv in &move_list {
-                    let promotion = match mv.flag {
-                        Flag::Promotion(piece, _) => Some(piece),
-                        _ => None,
+                    let promotion = match mv.flag.is_promo() {
+                        true => Some(mv.flag.get_promo_piece()),
+                        false => None,
                     };
-                    if str == move_notation(mv.from, mv.to, promotion).as_str() {
+                    if str == move_notation(mv.from.idx(), mv.to.idx(), promotion).as_str() {
                         print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
                         game.make_move(mv);
                         game.tt.set(mv.position_key, *mv);

--- a/src/engine/shared/helper_func/print_utility.rs
+++ b/src/engine/shared/helper_func/print_utility.rs
@@ -24,8 +24,8 @@ pub fn print_bitboard(bitboard: u64, mark: Option<i8>) {
 
 pub fn print_chess(game: &Game) {
     let chess_board: [String; 64] = array::from_fn(|idx| match game.squares[idx] {
-        Square::Empty => " ".to_string(),
-        Square::Occupied(piece) => piece.to_figure(),
+        None => " ".to_string(),
+        Some(piece) => piece.to_figure(),
     });
 
     print_board(&chess_board);
@@ -57,9 +57,9 @@ pub fn print_board(chess_board: &[String; 64]) {
 // pub fn print_move_list(moves: &[InternalMove]) {
 pub fn print_move_list(moves: &[PositionRev]) {
     for (idx, mv) in moves.iter().enumerate() {
-        let promotion = match mv.flag.is_promo() {
-            true => Some(mv.flag.get_promo_piece()),
-            false => None,
+        let promotion = match mv.flag {
+            Flag::Promotion(piece, _) => Some(piece),
+            _ => None,
         };
 
         println!("{}. Move: {}, (Score: {})", idx, move_notation(mv.from, mv.to, promotion), 0);

--- a/src/engine/shared/helper_func/print_utility.rs
+++ b/src/engine/shared/helper_func/print_utility.rs
@@ -54,18 +54,19 @@ pub fn print_board(chess_board: &[String; 64]) {
     println!();
 }
 
-pub fn print_move_list(moves: &[InternalMove]) {
+// pub fn print_move_list(moves: &[InternalMove]) {
+pub fn print_move_list(moves: &[PositionRev]) {
     for (idx, mv) in moves.iter().enumerate() {
-        let promotion = match mv.flag {
-            Flag::Promotion(promo_piece, _) => Some(promo_piece),
-            _ => None,
+        let promotion = match mv.flag.is_promo() {
+            true => Some(mv.flag.get_promo_piece()),
+            false => None,
         };
 
         println!("{}. Move: {}, (Score: {})", idx, move_notation(mv.from, mv.to, promotion), 0);
     }
 }
 
-pub fn move_notation(sq_from: usize, sq_to: usize, promotion: Option<Piece>) -> String {
+pub fn move_notation(sq_from: u8, sq_to: u8, promotion: Option<Piece>) -> String {
     match promotion {
         Some(piece) => {
             let p_notation = piece.to_char();
@@ -75,7 +76,7 @@ pub fn move_notation(sq_from: usize, sq_to: usize, promotion: Option<Piece>) -> 
     }
 }
 
-pub fn sq_notation(square: usize) -> String {
-    let (rank, file) = idx_to_position(square, None);
+pub fn sq_notation(square: u8) -> String {
+    let (rank, file) = idx_to_position(square as usize, None);
     format!("{}{}", FILE_LETTERS[file], rank + 1)
 }

--- a/src/engine/shared/structures/castling_struct.rs
+++ b/src/engine/shared/structures/castling_struct.rs
@@ -1,6 +1,7 @@
 use bitflags::bitflags;
 
 use super::color::*;
+use super::square::SqPos;
 use crate::engine::game::Game;
 use crate::engine::move_generation::mv_gen::*;
 use crate::engine::shared::structures::square::SqPos::*;
@@ -10,6 +11,11 @@ pub const CASTLE_DATA: [(usize, usize, CastlingRights, Color); 4] = [
     (A1 as usize, E1 as usize, CastlingRights::WQUEENSIDE, WHITE),
     (H8 as usize, E8 as usize, CastlingRights::BKINGSIDE, BLACK),
     (A8 as usize, E8 as usize, CastlingRights::BQUEENSIDE, BLACK),
+];
+
+pub const ROOK_SQ: [[(usize, usize); 2]; 2] = [
+    [(SqPos::H1 as usize, SqPos::F1 as usize), (SqPos::A1 as usize, SqPos::D1 as usize)],
+    [(SqPos::H8 as usize, SqPos::F8 as usize), (SqPos::A8 as usize, SqPos::D8 as usize)],
 ];
 
 bitflags! {

--- a/src/engine/shared/structures/internal_move.rs
+++ b/src/engine/shared/structures/internal_move.rs
@@ -1,52 +1,46 @@
+use crate::engine::game::Game;
+
 use super::castling_struct::*;
 use super::color::*;
 use super::piece::*;
 
-// Check about BigPawn Flag and what it does
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Flag {
     Quiet,
+    KingCastle,
+    QueenCastle,
     Capture(Piece),
-    EP(usize, Piece),
+    EP,
     Promotion(Piece, Option<Piece>),
-    KingSideCastle(usize, usize),
-    QueenSideCastle(usize, usize),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct InternalMove {
-    pub position_key: u64,
-    pub active_color: Color,
-    pub from: usize,
-    pub to: usize,
-    pub piece: Piece,
-    pub ep: Option<usize>,
-    pub castle: CastlingRights,
-    pub flag: Flag,
-    pub half_move: usize,
-    //TODO: Add Score
-}
-
-impl InternalMove {
-    pub fn init() -> Self {
-        Self {
-            position_key: 0u64,
-            active_color: WHITE,
-            from: 0,
-            to: 0,
-            piece: 0,
-            ep: None,
-            castle: CastlingRights::NONE,
-            flag: Flag::Quiet,
-            half_move: 0,
+impl Flag {
+    pub fn is_capture(&self) -> bool {
+        match *self {
+            Flag::Capture(_) | Flag::EP | Flag::Promotion(_, Some(_)) => true,
+            _ => false,
         }
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PositionRev {
+    pub from: u8,
+    pub to: u8,
+    pub piece: Piece,
+    pub capture: Option<Piece>,
+    pub flag: Flag,
+}
+
+impl PositionRev {
+    pub fn init(from: u8, to: u8, piece: Piece, capture: Option<Piece>, flag: Flag) -> Self {
+        Self { from, to, piece, capture, flag }
+    }
+}
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PositionIrr {
     pub key: u64,
-    pub side: Color,
+    pub color: Color,
     pub ep: Option<u8>,
     pub castle: CastlingRights,
     pub half_move: u8,
@@ -57,83 +51,25 @@ pub struct PositionIrr {
 impl PositionIrr {
     pub fn init(
         key: u64,
-        side: Color,
+        color: Color,
         ep: Option<u8>,
         castle: CastlingRights,
         half_move: u8,
         full_move: u16,
         score: isize,
     ) -> Self {
-        Self { key, side, ep, castle, half_move, full_move, score }
+        Self { key, color, ep, castle, half_move, full_move, score }
     }
-}
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[repr(u8)]
-pub enum PosFlag {
-    Quiet = 0,
-    DoublePushPawn = 1,
-    KingCastle = 2,
-    QueenCastle = 3,
-    Capture = 4,
-    EP = 5,
-    KnightPromo = 8,
-    BishopPromo = 9,
-    RookPromo = 10,
-    QueenPromo = 11,
-    KnightPromoCapture = 12,
-    BishopPromoCapture = 13,
-    RookPromoCapture = 14,
-    QueenPromoCapture = 15,
-}
-
-pub const PROMO: u8 = 0b1000;
-pub const CAPTURE: u8 = 0b0100;
-
-impl PosFlag {
-    pub fn get_promo_piece(&self) -> Piece {
-        match self {
-            PosFlag::KnightPromo | PosFlag::KnightPromoCapture => KNIGHT,
-            PosFlag::BishopPromo | PosFlag::BishopPromoCapture => KNIGHT,
-            PosFlag::RookPromo | PosFlag::RookPromoCapture => ROOK,
-            PosFlag::QueenPromo | PosFlag::QueenPromoCapture => QUEEN,
-            _ => panic!("Getting a promo piece when there is no promo flag"),
+    pub fn init_with_game(game: &Game) -> Self {
+        Self {
+            key: game.key,
+            color: game.color,
+            ep: game.ep,
+            castle: game.castling,
+            half_move: game.half_move,
+            full_move: game.full_move,
+            score: 0,
         }
-    }
-
-    pub fn is_promo(&self) -> bool {
-        (*self as u8) & PROMO != 0
-    }
-
-    pub fn is_capture(&self) -> bool {
-        (*self as u8) & CAPTURE != 0
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct PositionRev {
-    pub from: u8,
-    pub to: u8,
-    pub piece: Piece,
-    pub capture: Piece,
-    pub flag: PosFlag,
-}
-
-impl PositionRev {
-    pub fn init(from: u8, to: u8, piece: Piece, capture: Piece, flag: PosFlag) -> Self {
-        Self { from, to, piece, capture, flag }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct Position(PositionRev, PositionIrr);
-
-impl Position {
-    pub fn get_rev(&self) -> PositionRev {
-        self.0
-    }
-
-    pub fn get_irr(&self) -> PositionIrr {
-        self.1
     }
 }

--- a/src/engine/shared/structures/internal_move.rs
+++ b/src/engine/shared/structures/internal_move.rs
@@ -42,3 +42,98 @@ impl InternalMove {
         }
     }
 }
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PositionIrr {
+    pub key: u64,
+    pub side: Color,
+    pub ep: Option<u8>,
+    pub castle: CastlingRights,
+    pub half_move: u8,
+    pub full_move: u16,
+    pub score: isize,
+}
+
+impl PositionIrr {
+    pub fn init(
+        key: u64,
+        side: Color,
+        ep: Option<u8>,
+        castle: CastlingRights,
+        half_move: u8,
+        full_move: u16,
+        score: isize,
+    ) -> Self {
+        Self { key, side, ep, castle, half_move, full_move, score }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum PosFlag {
+    Quiet = 0,
+    DoublePushPawn = 1,
+    KingCastle = 2,
+    QueenCastle = 3,
+    Capture = 4,
+    EP = 5,
+    KnightPromo = 8,
+    BishopPromo = 9,
+    RookPromo = 10,
+    QueenPromo = 11,
+    KnightPromoCapture = 12,
+    BishopPromoCapture = 13,
+    RookPromoCapture = 14,
+    QueenPromoCapture = 15,
+}
+
+pub const PROMO: u8 = 0b1000;
+pub const CAPTURE: u8 = 0b0100;
+
+impl PosFlag {
+    pub fn get_promo_piece(&self) -> Piece {
+        match self {
+            PosFlag::KnightPromo | PosFlag::KnightPromoCapture => KNIGHT,
+            PosFlag::BishopPromo | PosFlag::BishopPromoCapture => KNIGHT,
+            PosFlag::RookPromo | PosFlag::RookPromoCapture => ROOK,
+            PosFlag::QueenPromo | PosFlag::QueenPromoCapture => QUEEN,
+            _ => panic!("Getting a promo piece when there is no promo flag"),
+        }
+    }
+
+    pub fn is_promo(&self) -> bool {
+        (*self as u8) & PROMO != 0
+    }
+
+    pub fn is_capture(&self) -> bool {
+        (*self as u8) & CAPTURE != 0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PositionRev {
+    pub from: u8,
+    pub to: u8,
+    pub piece: Piece,
+    pub capture: Piece,
+    pub flag: PosFlag,
+}
+
+impl PositionRev {
+    pub fn init(from: u8, to: u8, piece: Piece, capture: Piece, flag: PosFlag) -> Self {
+        Self { from, to, piece, capture, flag }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Position(PositionRev, PositionIrr);
+
+impl Position {
+    pub fn get_rev(&self) -> PositionRev {
+        self.0
+    }
+
+    pub fn get_irr(&self) -> PositionIrr {
+        self.1
+    }
+}

--- a/src/engine/shared/structures/square.rs
+++ b/src/engine/shared/structures/square.rs
@@ -1,5 +1,3 @@
-use super::piece::Piece;
-
 #[rustfmt::skip]
 pub enum SqPos {
     A1 = 0,  B1 = 1,  C1 = 2,  D1 = 3,  E1 = 4,  F1 = 5,  G1 = 6,  H1 = 7,
@@ -17,11 +15,4 @@ impl SqPos {
     pub fn idx(self) -> usize {
         self as usize
     }
-}
-
-/** Determines if the square is empty or occupied. */
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum Square {
-    Empty,
-    Occupied(Piece),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use engine::shared::helper_func::play_chess_utility::play_chess;
 pub mod engine;
 
 fn main() {
-    // let mut game = Game::read_fen(FEN_MATE_IN_4);
-    let mut game = Game::initialize();
+    let mut game = Game::read_fen(FEN_MATE_IN_4);
+    // let mut game = Game::initialize();
     let mut info = SearchInfo::init();
     play_chess(&mut game, &mut info);
 }


### PR DESCRIPTION
# Jira Ticket: DCE-52
## Summary (Provide a summary of the changes.)
- Renamed Internal Move to PositionRev (Position Revesable) and Updated Its implementation.
- 

## Checklist
- [x] All Tests are Correct.
- [x] Merged with the master branch.

## Additional Notes (Any additional context, screenshots, or relevant information.)
- In the future I should check about casting from big numbers to low (u64 to u8, is I think an expensive operation).
- https://rustc-dev-guide.rust-lang.org/building/optimized-build.html (for optimized build)
- https://github.com/rust-lang/rust/issues/45222 (range ".." and "..=" are not the same).
- On the Perft test the sq_attack still gives the most time usage (50%).
- Also I when I am doing the finishing touches of the chess program I should Use a good profiler and I need to avoid as much if's as possible. (I think if statments take 1ms on 1M iterations). The first if's that I will need to remove are the ones inside the creation of reverasable position.
